### PR TITLE
add volatile to 'done'

### DIFF
--- a/derecho/experiments/ssd_bw_test.cpp
+++ b/derecho/experiments/ssd_bw_test.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
     long long unsigned int block_size = 1000000ull;
     int num_messages = 100;
 
-    bool done = false;
+    volatile bool done = false;
     auto stability_callback = [
         &num_messages,
         &done,


### PR DESCRIPTION
In our cluster, `ssd_bw_test ` loops infinitely at [line 172](https://github.com/Derecho-Project/derecho-unified/blob/master/derecho/experiments/ssd_bw_test.cpp#L172) becasue the compiler may have optimized the `done` variable.