### PR TITLE
Added the unified configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -std=c++1z -O0 -Wall -ggdb -
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++1z -O3 -Wall -DNOLOG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -std=c++1z -O3 -Wall -ggdb -gdwarf-3 -DNOLOG")
 
+add_subdirectory(conf)
 add_subdirectory(derecho)
 add_subdirectory(rdmc)
 add_subdirectory(sst)

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required (VERSION 3.1)
+project (conf)
+
+# C FLAGS
+set(CMAKE_C_FLAGS_RELEASE "-std=c++1z ${CMAKE_C_FLAGS} -Wall -O3 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64")
+set(CMAKE_C_FLAGS_DEBUG   "-std=c++1z ${CMAKE_C_FLAGS} -Wall -O0 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -ggdb -gdwarf-3 -D_DEBUG -DSPDLOG_TRACE_ON")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-std=c++1z ${CMAKE_C_FLAGS} -Wall -O3 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -ggdb -gdwarf-3 -D_PERFORMANCE_DEBUG")
+
+# CXX FLAGS
+set(CMAKE_CXX_FLAGS_RELEASE "-std=c++1z ${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")
+set(CMAKE_CXX_FLAGS_DEBUG   "-std=c++1z ${CMAKE_CXX_FLAGS} -Wall -O0 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_DEBUG -DSPDLOG_TRACE_ON -ggdb -gdwarf-3")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-std=c++1z ${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC -D_REENTRANT -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -ggdb -gdwarf-3 -D_PERFORMANCE_DEBUG")
+
+include_directories(${derecho_SOURCE_DIR}/third_party/getpot)
+include_directories(${derecho_SOURCE_DIR}/third_party/spdlog/include)
+
+add_library(conf SHARED conf.hpp conf.cpp)
+
+add_executable(conftst test.cpp)
+target_link_libraries(conftst conf pthread)

--- a/conf/conf.cpp
+++ b/conf/conf.cpp
@@ -1,0 +1,85 @@
+#include "conf.hpp"
+#include <cstdlib>
+#include <sys/stat.h>
+#include <unistd.h>
+#ifndef NDEBUG
+#include <spdlog/spdlog.h>
+#endif//NDEBUG
+
+namespace derecho {
+
+static const char * default_conf_file = "derecho.cfg";
+
+std::unique_ptr<Conf> Conf::singleton = nullptr;
+
+std::atomic<uint32_t> Conf::singleton_initialized_flag = 0;
+#define CONF_UNINITIALIZED      (0)
+#define CONF_INITIALIZING       (1)
+#define CONF_INITIALIZED        (2)
+
+#ifndef NDEBUG
+  inline auto dbgConsole() {
+    static auto con = spdlog::stdout_color_mt("conf");
+    return con;
+  }
+  #define dbg_trace(...) dbgConsole()->trace(__VA_ARGS__)
+  #define dbg_debug(...) dbgConsole()->debug(__VA_ARGS__)
+  #define dbg_info(...) dbgConsole()->info(__VA_ARGS__)
+  #define dbg_warn(...) dbgConsole()->warn(__VA_ARGS__)
+  #define dbg_error(...) dbgConsole()->error(__VA_ARGS__)
+  #define dbg_crit(...) dbgConsole()->critical(__VA_ARGS__)
+  #define dbg_flush() dbgConsole()->flush()
+#else
+  #define dbg_trace(...)
+  #define dbg_debug(...)
+  #define dbg_info(...)
+  #define dbg_warn(...)
+  #define dbg_error(...)
+  #define dbg_crit(...)
+  #define dbg_flush()
+#endif //NDEBUG
+
+void Conf::initialize(const char * conf_file){
+  uint32_t expected = CONF_UNINITIALIZED;
+  // if not initialized(0), set the flag to under initialization ... 
+  if (Conf::singleton_initialized_flag.compare_exchange_strong(
+       expected,CONF_INITIALIZING,std::memory_order_acq_rel))
+  {
+    // 1 - get configuration file path
+    std::string real_conf_file;
+    struct stat buffer;
+    if (conf_file)
+      real_conf_file = conf_file;
+    else if ( std::getenv("DERECHO_CONF_FILE") )
+      // try environment variable: DERECHO_CONF_FILE
+      real_conf_file = std::getenv( "DERECHO_CONF_FILE" );
+    else if (stat (default_conf_file,&buffer) == 0) {
+      if (S_ISREG(buffer.st_mode) && (S_IRUSR | buffer.st_mode)) {
+        real_conf_file = default_conf_file;
+      }
+    } else
+      real_conf_file.clear();
+
+    // 2 - load configuration
+    GetPot * cfg = nullptr;
+    if (!real_conf_file.empty()) {
+      dbg_trace("load configuration from file:{0}.", real_conf_file);
+      cfg = new GetPot(real_conf_file);
+    }
+    else
+      dbg_trace("no configuration is found...load defaults.");
+    Conf::singleton = std::make_unique<Conf>(cfg);
+    delete cfg;
+
+    // 3 - set the flag to initialized
+    Conf::singleton_initialized_flag.store(CONF_INITIALIZED,std::memory_order_acq_rel);
+  }
+}
+
+const Conf* Conf::get() noexcept {
+  while (Conf::singleton_initialized_flag.load(std::memory_order_acquire) != CONF_INITIALIZED)
+    Conf::initialize(nullptr);
+  return Conf::singleton.get();
+}
+
+}

--- a/conf/conf.cpp
+++ b/conf/conf.cpp
@@ -82,4 +82,24 @@ const Conf* Conf::get() noexcept {
   return Conf::singleton.get();
 }
 
+const std::string & getConfString(const std::string & key){
+  return Conf::get()->getString(key);
+}
+
+const int32_t getConfInt32(const std::string & key){
+  return Conf::get()->getInt32(key);
+}
+
+const int64_t getConfInt64(const std::string & key){
+  return Conf::get()->getInt64(key);
+}
+
+const float getConfFloat(const std::string & key){
+  return Conf::get()->getFloat(key);
+}
+
+const double getConfDouble(const std::string & key){
+  return Conf::get()->getDouble(key);
+}
+
 }

--- a/conf/conf.hpp
+++ b/conf/conf.hpp
@@ -1,0 +1,94 @@
+#ifndef CONF_HPP
+#define CONF_HPP
+
+#include <memory>
+#include <atomic>
+#include <inttypes.h>
+#include <GetPot>
+#include <map>
+
+namespace derecho {
+
+#define CONF_ENTRY_INTEGER(name,section,string) \
+
+  /** RMDA Hardware Configuration **/
+  class RDMAHwConf {
+  public:
+    RDMAHwConf(GetPot &cfg);
+    const char * provider;
+    const char * domain;
+    const uint32_t rx_depth;
+    const uint32_t tx_depth;
+  };
+
+  /** SST Configuration **/
+  class SSTConf {
+  public:
+    constexpr uint32_t getSSTPort() const noexcept;
+  };
+
+  /** RDMC Configuration **/
+  class RDMCConf {
+  public:
+    constexpr uint32_t getRDMCPort() const noexcept;
+  };
+
+  /** Persistent Configuration **/
+  class PersistentConf {
+  public:
+    constexpr uint32_t getPersMedia() const noexcept;
+  };
+
+  /** The single configuration file for derecho **/
+  class Conf {
+  private:
+    // Configuration Table: 
+    // config name --> default value
+    std::map<const std::string, std::string> config = {
+      {"RDMA/provider",         "sockets"},
+      {"RDMA/domain",           "eth0"},
+      {"RDMA/tx_depth",         "256"},
+      {"RDMA/rx_depth",         "256"}
+    };
+  public:
+    /** Constructor **/
+    Conf(GetPot * getpotcfg) noexcept {
+      // load configuration
+      if (getpotcfg != nullptr) {
+        for (std::map<const std::string, std::string>::iterator it = this->config.begin();it != this->config.end(); it++) {
+          this->config[it->first] = (*getpotcfg)(it->first,it->second);
+        }
+      }
+    }
+    /** get configuration **/
+    const std::string & getString(const std::string & key) const {
+      return this->config.at(key);
+    }
+    const int32_t getInt32(const std::string & key) const {
+      return (const int32_t)std::stoi(this->config.at(key));
+    }
+    const int64_t getInt64(const std::string & key) const {
+      return (const int64_t)std::stoll(this->config.at(key));
+    }
+    const float getFloat(const std::string & key) const {
+      return (const float)std::stof(this->config.at(key));
+    }
+    const double getDouble(const std::string & key ) const {
+      return (const float)std::stod(this->config.at(key));
+    }
+    // Initialize the singleton from the configuration file
+    // 1) if conf_file is not null, use it, otherwise,
+    // 2) try DERECHO_CONF_FILE environment, otherwise,
+    // 3) use "derecho.cfg" at local, otherwise,
+    // 4) use all default settings.
+    // Note: initialize will be called on the first 'get()' if it is not called before.
+    static void initialize(const char * conf_file = nullptr);
+    static const Conf* get() noexcept;
+
+  private:
+    // singleton
+    static std::unique_ptr<Conf> singleton;
+    static std::atomic<uint32_t> singleton_initialized_flag;
+  };
+}
+#endif//CONF_HPP

--- a/conf/conf.hpp
+++ b/conf/conf.hpp
@@ -11,44 +11,35 @@ namespace derecho {
 
 #define CONF_ENTRY_INTEGER(name,section,string) \
 
-  /** RMDA Hardware Configuration **/
-  class RDMAHwConf {
-  public:
-    RDMAHwConf(GetPot &cfg);
-    const char * provider;
-    const char * domain;
-    const uint32_t rx_depth;
-    const uint32_t tx_depth;
-  };
-
-  /** SST Configuration **/
-  class SSTConf {
-  public:
-    constexpr uint32_t getSSTPort() const noexcept;
-  };
-
-  /** RDMC Configuration **/
-  class RDMCConf {
-  public:
-    constexpr uint32_t getRDMCPort() const noexcept;
-  };
-
-  /** Persistent Configuration **/
-  class PersistentConf {
-  public:
-    constexpr uint32_t getPersMedia() const noexcept;
-  };
-
   /** The single configuration file for derecho **/
   class Conf {
   private:
     // Configuration Table: 
     // config name --> default value
+#define CONF_DERECHO_GMS_PORT   "DERECHO/gms_port"
+#define CONF_DERECHO_RPC_PORT   "DERECHO/rpc_port"
+
+#define CONF_RDMA_PROVIDER      "RDMA/provider"
+#define CONF_RDMA_DOMAIN        "RDMA/domain"
+#define CONF_RDMA_TX_DEPTH      "RDMA/tx_depth"
+#define CONF_RDMA_RX_DEPTH      "RDMA/rx_depth"
+
+#define CONF_SST_TCP_PORT       "SST/tcp_port"
+#define CONF_RDMC_TCP_PORT      "RDMC/tcp_port"
+
     std::map<const std::string, std::string> config = {
-      {"RDMA/provider",         "sockets"},
-      {"RDMA/domain",           "eth0"},
-      {"RDMA/tx_depth",         "256"},
-      {"RDMA/rx_depth",         "256"}
+      // [DERECHO]
+      {CONF_DERECHO_GMS_PORT,   "23580"},
+      {CONF_DERECHO_RPC_PORT,   "28366"},
+      // [RDMA]
+      {CONF_RDMA_PROVIDER,      "sockets"},
+      {CONF_RDMA_DOMAIN,        "eth0"},
+      {CONF_RDMA_TX_DEPTH,      "256"},
+      {CONF_RDMA_RX_DEPTH,      "256"},
+      // [SST]
+      {CONF_SST_TCP_PORT,       "37683"},
+      // [RDMC]
+      {CONF_RDMC_TCP_PORT,      "31675"}
     };
   public:
     /** Constructor **/
@@ -90,5 +81,12 @@ namespace derecho {
     static std::unique_ptr<Conf> singleton;
     static std::atomic<uint32_t> singleton_initialized_flag;
   };
+
+  // helpers
+  const std::string & getConfString(const std::string & key);
+  const int32_t getConfInt32(const std::string & key);
+  const int64_t getConfInt64(const std::string & key);
+  const float getConfFloat(const std::string & key);
+  const double getConfDouble(const std::string & key);
 }
 #endif//CONF_HPP

--- a/conf/derecho-default.cfg
+++ b/conf/derecho-default.cfg
@@ -1,5 +1,8 @@
-[GLOBAL]
-
+[DERECHO]
+# derecho gms port
+gms_port = 23580
+# derecho rpc port
+rpc_port = 28366
 
 # RDMA section contains configurations of the following
 # - which RDMA device to use
@@ -39,9 +42,13 @@ rx_depth = 256
 
 # SST configurations
 [SST]
+# sst tcp port
+tcp_port = 37683
 
 # RDMC configurations
 [RDMC]
+# rdmc tcp port
+tcp_port = 31675
 
 # Persistent configurations
 [PERS]

--- a/conf/derecho-default.cfg
+++ b/conf/derecho-default.cfg
@@ -1,0 +1,48 @@
+[GLOBAL]
+
+
+# RDMA section contains configurations of the following
+# - which RDMA device to use
+# - device configurations
+[RDMA]
+# 1. provider = bgq|gni|mlx|netdir|psm|psm2|rxd|rxm|shm|sockets|udp|usnic|verbs
+# possible options(only 'sockets' and 'verbs' providers are tested so far):
+# bgq     - The Blue Gene/Q Fabric Provider
+# gni     - The GNI Fabric Provider (Cray XC (TM) systems)
+# mlx     - The MLX Fabric Provider (UCX library)
+# netdir  - The Network Direct Fabric Provider (Microsoft Network Direct SPI)
+# psm     - The PSM Fabric Provider
+# psm2    - The PSM2 Fabric Provider
+# rxd     - The RxD (RDM over DGRAM) Utility Provider
+# rxm     - The RxM (RDM over MSG) Utility Provider
+# shm     - The SHM Fabric Provider
+# sockets - The Sockets Fabric Provider
+# udp     - The UDP Fabric Provider
+# usnic   - The usNIC Fabric Provider(Cisco VIC)
+# verbs   - The Verbs Fabric Provider
+provider = sockets
+
+# 2. domain
+# For sockets provider, domain is the NIC name (ifconfig | grep -v -e "^ ")
+# For verbs provider, domain is the device name (ibv_devices)
+domain = eth0
+
+# 3. tx_depth 
+# tx_depth applies to hints->tx_attr->size, where hint is a struct fi_info object.
+# see https://ofiwg.github.io/libfabric/master/man/fi_getinfo.3.html
+tx_depth = 256
+
+# 4. rx_depth:
+# rx_depth applies to hints->rx_attr->size, where hint is a struct fi_info object.
+# see https://ofiwg.github.io/libfabric/master/man/fi_getinfo.3.html
+rx_depth = 256
+
+# SST configurations
+[SST]
+
+# RDMC configurations
+[RDMC]
+
+# Persistent configurations
+[PERS]
+

--- a/conf/test.cpp
+++ b/conf/test.cpp
@@ -1,0 +1,16 @@
+#include "conf.hpp"
+#include <iostream>
+#include <spdlog/spdlog.h>
+
+int main(int argc, char **argv) {
+  spdlog::set_level(spdlog::level::trace);
+  std::cout<<"list of configurations:"<<std::endl;
+  const derecho::Conf * pc = derecho::Conf::get();
+  // const std::string k("RDMA/provider");
+  // const std::string x = pc->getString(k);
+  std::cout<<"RDMA/provider:\t"<<(derecho::Conf::get()->getString("RDMA/provider"))<<std::endl;
+  std::cout<<"RDMA/domain:\t"<<(derecho::Conf::get()->getString("RDMA/domain"))<<std::endl;
+  std::cout<<"RDMA/rx_depth:\t"<<(derecho::Conf::get()->getInt32("RDMA/rx_depth"))<<std::endl;
+  std::cout<<"RDMA/tx_depth:\t"<<(derecho::Conf::get()->getInt32("RDMA/tx_depth"))<<std::endl;
+  return 0;
+}

--- a/derecho/CMakeLists.txt
+++ b/derecho/CMakeLists.txt
@@ -22,11 +22,11 @@ link_directories(${derecho_SOURCE_DIR}/third_party/mutils-serialization)
 link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/src/.libs)
 
 add_library(derecho SHARED derecho_sst.cpp view.cpp view_manager.cpp rpc_manager.cpp p2p_connections.cpp multicast_group.cpp raw_subgroup.cpp subgroup_functions.cpp connection_manager.cpp)
-target_link_libraries(derecho rdmacm ibverbs rt pthread atomic rdmc sst mutils mutils-serialization persistent)
+target_link_libraries(derecho rdmacm ibverbs rt pthread atomic rdmc sst mutils mutils-serialization persistent conf)
 add_dependencies(derecho mutils_serialization_target mutils_target libfabric_target)
 
 add_executable(subgroup_function_tester subgroup_function_tester.cpp)
-target_link_libraries(subgroup_function_tester derecho)
+target_link_libraries(subgroup_function_tester derecho conf)
 
 add_custom_target(format_derecho 
 	COMMAND clang-format-3.8 -i *.cpp *.h

--- a/derecho/derecho.h
+++ b/derecho/derecho.h
@@ -10,7 +10,6 @@
 
 #include "derecho_exception.h"
 #include "derecho_internal.h"
-#include "derecho_ports.h"
 #include "group.h"
 #include "register_rpc_functions.h"
 #include "subgroup_functions.h"

--- a/derecho/derecho_ports.h
+++ b/derecho/derecho_ports.h
@@ -1,8 +1,0 @@
-#pragma once
-
-namespace derecho {
-const static int derecho_gms_port = 23580;
-const static int derecho_rpc_port = 28366;
-const static int rdmc_tcp_port = 31675;
-const static int sst_tcp_port = 37683;
-}  // namespace derecho

--- a/derecho/experiments/CMakeLists.txt
+++ b/derecho/experiments/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(${derecho_SOURCE_DIR}/third_party/mutils)
 include_directories(${derecho_SOURCE_DIR}/third_party/mutils-serialization)
 include_directories(${derecho_SOURCE_DIR}/third_party/spdlog/include)
 include_directories(${derecho_SOURCE_DIR}/third_party/libfabric/include)
+include_directories(${derecho_SOURCE_DIR}/third_party/getpot)
 
 link_directories(${derecho_SOURCE_DIR}/third_party/mutils)
 link_directories(${derecho_SOURCE_DIR}/third_party/mutils-serialization)
@@ -18,155 +19,155 @@ link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/src/.libs)
 
 # test_group_interface
 add_executable(test_group_interface test_group_interface.cpp initialize.cpp )
-target_link_libraries(test_group_interface derecho)
+target_link_libraries(test_group_interface derecho conf)
 
 # single_sender_one_message
 add_executable(single_sender_one_message single_sender_one_message.cpp initialize.cpp )
-target_link_libraries(single_sender_one_message derecho)
+target_link_libraries(single_sender_one_message derecho conf)
 
 # single_sender_multiple_messages
 add_executable(single_sender_multiple_messages single_sender_multiple_messages.cpp initialize.cpp )
-target_link_libraries(single_sender_multiple_messages derecho)
+target_link_libraries(single_sender_multiple_messages derecho conf)
 
 # multiple_senders_multiple_messages
 add_executable(multiple_senders_multiple_messages multiple_senders_multiple_messages.cpp initialize.cpp )
-target_link_libraries(multiple_senders_multiple_messages derecho)
+target_link_libraries(multiple_senders_multiple_messages derecho conf)
 
 # rdmc_test
 add_executable(rdmc_test rdmc_test.cpp block_size.cpp)
-target_link_libraries(rdmc_test rdmc derecho)
+target_link_libraries(rdmc_test rdmc derecho conf)
 
 # derecho_bw_test
 add_executable(derecho_bw_test derecho_bw_test.cpp block_size.cpp aggregate_bandwidth.cpp initialize.cpp )
-target_link_libraries(derecho_bw_test derecho)
+target_link_libraries(derecho_bw_test derecho conf)
 
 # subgroup_scaling
 add_executable(subgroup_scaling_test subgroup_scaling_test.cpp block_size.cpp aggregate_bandwidth.cpp initialize.cpp)
-target_link_libraries(subgroup_scaling_test derecho)
+target_link_libraries(subgroup_scaling_test derecho conf)
 
 # latency_test
 add_executable(latency_test latency_test.cpp block_size.cpp)
-target_link_libraries(latency_test derecho)
+target_link_libraries(latency_test derecho conf)
 
 # derecho_caller_test
 add_executable(derecho_caller_test derecho_caller_test.cpp block_size.cpp)
-target_link_libraries(derecho_caller_test derecho mutils mutils-serialization)
+target_link_libraries(derecho_caller_test derecho mutils mutils-serialization conf)
 
 # p2p_latency_test
 add_executable(p2p_latency_test p2p_latency_test.cpp block_size.cpp)
-target_link_libraries(p2p_latency_test derecho mutils mutils-serialization)
+target_link_libraries(p2p_latency_test derecho mutils mutils-serialization conf)
 
 # subgroup_test
 add_executable(subgroup_test subgroup_test.cpp initialize.cpp)
-target_link_libraries(subgroup_test derecho)
+target_link_libraries(subgroup_test derecho conf)
 
 # raw_send_test
 add_executable(raw_send_test raw_send_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(raw_send_test derecho mutils mutils-serialization)
+target_link_libraries(raw_send_test derecho mutils mutils-serialization conf)
 
 # ssd_bw_test
 add_executable(ssd_bw_test ssd_bw_test.cpp block_size.cpp aggregate_bandwidth.cpp initialize.cpp )
-target_link_libraries(ssd_bw_test derecho)
+target_link_libraries(ssd_bw_test derecho conf)
 
 # gms_test
 add_executable(gms_test gms_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(gms_test derecho)
+target_link_libraries(gms_test derecho conf)
 
 # gms_test
 add_executable(gms_test2 gms_test2.cpp block_size.cpp initialize.cpp)
-target_link_libraries(gms_test2 derecho)
+target_link_libraries(gms_test2 derecho conf)
 
 # gms_bw_test
 add_executable(gms_bw_test gms_bw_test.cpp initialize.cpp)
-target_link_libraries(gms_bw_test derecho)
+target_link_libraries(gms_bw_test derecho conf)
 
 # window_size_test
 add_executable(window_size_test window_size_test.cpp block_size.cpp aggregate_bandwidth.cpp initialize.cpp )
-target_link_libraries(window_size_test derecho)
+target_link_libraries(window_size_test derecho conf)
 
 # write_to_ssd
 add_executable(write_to_ssd write_to_ssd.cpp block_size.cpp aggregate_bandwidth.cpp initialize.cpp )
-target_link_libraries(write_to_ssd derecho)
+target_link_libraries(write_to_ssd derecho conf)
 
 # timeline_test
 add_executable(timeline_test timeline_test.cpp initialize.cpp)
-target_link_libraries(timeline_test derecho)
+target_link_libraries(timeline_test derecho conf)
 
 add_executable(viewchange_timeline viewchange_timeline.cpp initialize.cpp)
-target_link_libraries(viewchange_timeline derecho)
+target_link_libraries(viewchange_timeline derecho conf)
 
 # p2p_query_test
 add_executable(p2p_query_test p2p_query_test.cpp initialize.cpp)
-target_link_libraries(p2p_query_test derecho)
+target_link_libraries(p2p_query_test derecho conf)
 
 add_executable(repeated_rpc_test repeated_rpc_test.cpp initialize.cpp)
-target_link_libraries(repeated_rpc_test derecho)
+target_link_libraries(repeated_rpc_test derecho conf)
 
 # typed_subgroup_test
 add_executable(typed_subgroup_test typed_subgroup_test.cpp initialize.cpp)
-target_link_libraries(typed_subgroup_test derecho)
+target_link_libraries(typed_subgroup_test derecho conf)
 
 # long_subgroup_test
 add_executable(long_subgroup_test long_subgroup_test.cpp initialize.cpp)
-target_link_libraries(long_subgroup_test derecho)
+target_link_libraries(long_subgroup_test derecho conf)
 
 # typed_subgroup_bw_test
 add_executable(typed_subgroup_bw_test typed_subgroup_bw_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(typed_subgroup_bw_test derecho)
+target_link_libraries(typed_subgroup_bw_test derecho conf)
 
 # persistent_typed_subgroup_bw_test
 add_executable(persistent_typed_subgroup_bw_test persistent_typed_subgroup_bw_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(persistent_typed_subgroup_bw_test derecho)
+target_link_libraries(persistent_typed_subgroup_bw_test derecho conf)
 
 # volatile_typed_subgroup_bw_test
 add_executable(volatile_typed_subgroup_bw_test volatile_typed_subgroup_bw_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(volatile_typed_subgroup_bw_test derecho)
+target_link_libraries(volatile_typed_subgroup_bw_test derecho conf)
 
 # volatile_temporal_query_test
 add_executable(volatile_temporal_query_test volatile_temporal_query_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(volatile_temporal_query_test derecho)
+target_link_libraries(volatile_temporal_query_test derecho conf)
 
 # persistent_temporal_query_test
 add_executable(persistent_temporal_query_test persistent_temporal_query_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(persistent_temporal_query_test derecho)
+target_link_libraries(persistent_temporal_query_test derecho conf)
 
 # volatile_temporal_stability_test.cpp
 add_executable(volatile_temporal_stability_test volatile_temporal_stability_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(volatile_temporal_stability_test derecho)
+target_link_libraries(volatile_temporal_stability_test derecho conf)
 
 # persistent_temporal_stability_test
 add_executable(persistent_temporal_stability_test persistent_temporal_stability_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(persistent_temporal_stability_test derecho)
+target_link_libraries(persistent_temporal_stability_test derecho conf)
 
 # persistent_latency_test
 add_executable(persistent_latency_test persistent_latency_test.cpp block_size.cpp initialize.cpp)
-target_link_libraries(persistent_latency_test derecho)
+target_link_libraries(persistent_latency_test derecho conf)
 
 # smart membership function
 add_executable(smart_membership_function_test smart_membership_function_test.cpp initialize.cpp)
-target_link_libraries(smart_membership_function_test derecho)
+target_link_libraries(smart_membership_function_test derecho conf)
 
 # persistent_typed_subgroup_test
 add_executable(persistent_typed_subgroup_test persistent_typed_subgroup_test.cpp initialize.cpp)
-target_link_libraries(persistent_typed_subgroup_test derecho)
+target_link_libraries(persistent_typed_subgroup_test derecho conf)
 
 #shard_iterator_p2p_test
 add_executable(shard_iterator_p2p_test shard_iterator_p2p_test.cpp initialize.cpp)
-target_link_libraries(shard_iterator_p2p_test derecho)
+target_link_libraries(shard_iterator_p2p_test derecho conf)
 
 add_executable(persistent_rejoin_test persistent_rejoin_test.cpp initialize.cpp)
-target_link_libraries(persistent_rejoin_test derecho)
+target_link_libraries(persistent_rejoin_test derecho conf)
 
 # scaling_subgroup_test
 add_executable(scaling_subgroup_test scaling_subgroup_test.cpp initialize.cpp)
-target_link_libraries(scaling_subgroup_test derecho)
+target_link_libraries(scaling_subgroup_test derecho conf)
 
 # server_client_p2p
 add_executable(server_client_p2p server_client_p2p.cpp initialize.cpp)
-target_link_libraries(server_client_p2p derecho)
+target_link_libraries(server_client_p2p derecho conf)
 
 # asynchronous_dht
 add_executable(asynchronous_dht asynchronous_dht.cpp initialize.cpp)
-target_link_libraries(asynchronous_dht derecho)
+target_link_libraries(asynchronous_dht derecho conf)
 
 add_custom_target(format_experiments clang-format-3.8 -i *.cpp *.h)

--- a/derecho/experiments/asynchronous_dht.cpp
+++ b/derecho/experiments/asynchronous_dht.cpp
@@ -4,6 +4,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include <mutils-serialization/SerializationSupport.hpp>
+#include "conf/conf.hpp"
 
 template <class DataType>
 class HashTable;
@@ -106,9 +107,9 @@ int main() {
     auto HashTableGenerator = [&](PersistentRegistry*) { return std::make_unique<HashTable<std::string>>(); };
 
     if(my_ip == leader_ip) {
-        group = new derecho::Group<HashTable<std::string>>(node_id, my_ip, callback_set, subgroup_info, derecho_params, std::vector<derecho::view_upcall_t>{announce_groups_provisioned}, derecho::derecho_gms_port, HashTableGenerator);
+        group = new derecho::Group<HashTable<std::string>>(node_id, my_ip, callback_set, subgroup_info, derecho_params, std::vector<derecho::view_upcall_t>{announce_groups_provisioned}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT), HashTableGenerator);
     } else {
-        group = new derecho::Group<HashTable<std::string>>(node_id, my_ip, leader_ip, callback_set, subgroup_info, std::vector<derecho::view_upcall_t>{announce_groups_provisioned}, derecho::derecho_gms_port, HashTableGenerator);
+        group = new derecho::Group<HashTable<std::string>>(node_id, my_ip, leader_ip, callback_set, subgroup_info, std::vector<derecho::view_upcall_t>{announce_groups_provisioned}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT), HashTableGenerator);
     }
 
     std::unique_lock<std::mutex> main_lock(main_mutex);

--- a/derecho/experiments/derecho_caller_test.cpp
+++ b/derecho/experiments/derecho_caller_test.cpp
@@ -9,6 +9,7 @@
 #include "derecho/derecho.h"
 #include "rdmc/util.h"
 #include "spdlog/spdlog.h"
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -102,7 +103,7 @@ int main(int argc, char* argv[]) {
     if(my_id == 0) {
         managed_group = new derecho::Group<test1_str>(
                 my_id, my_ip, {stability_callback, {}}, subgroup_info,
-                derecho_params, {new_view_callback}, derecho::derecho_gms_port,
+                derecho_params, {new_view_callback}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 [](PersistentRegistry* pr) { return std::make_unique<test1_str>(); });
     }
 
@@ -110,7 +111,7 @@ int main(int argc, char* argv[]) {
         managed_group = new derecho::Group<test1_str>(
                 my_id, my_ip, leader_ip,
                 {stability_callback, {}}, subgroup_info,
-                {new_view_callback}, derecho::derecho_gms_port,
+                {new_view_callback}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 [](PersistentRegistry* pr) { return std::make_unique<test1_str>(); });
     }
 

--- a/derecho/experiments/long_subgroup_test.cpp
+++ b/derecho/experiments/long_subgroup_test.cpp
@@ -9,6 +9,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include "test_objects.h"
+#include "conf/conf.hpp"
 
 using derecho::ExternalCaller;
 using derecho::Replicated;
@@ -82,12 +83,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     }
 

--- a/derecho/experiments/p2p_latency_test.cpp
+++ b/derecho/experiments/p2p_latency_test.cpp
@@ -3,6 +3,7 @@
 #include "block_size.h"
 #include "derecho/derecho.h"
 #include "rdmc/util.h"
+#include "conf/conf.hpp"
 
 using std::cin;
 using std::cout;
@@ -65,7 +66,7 @@ int main() {
     if(my_id == 0) {
         managed_group = new derecho::Group<test1_str>(
                 my_id, my_ip, {{}, {}}, subgroup_info,
-                derecho_params, {}, derecho::derecho_gms_port,
+                derecho_params, {}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 [](PersistentRegistry* pr) { return std::make_unique<test1_str>(); });
         derecho::Replicated<test1_str>& rpc_handle = managed_group->get_subgroup<test1_str>(0);
 
@@ -93,7 +94,7 @@ int main() {
         managed_group = new derecho::Group<test1_str>(
                 my_id, my_ip, leader_ip,
                 {{}, {}}, subgroup_info,
-                {}, derecho::derecho_gms_port,
+                {}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 [](PersistentRegistry* pr) { return std::make_unique<test1_str>(); });
     }
     managed_group->barrier_sync();

--- a/derecho/experiments/p2p_query_test.cpp
+++ b/derecho/experiments/p2p_query_test.cpp
@@ -10,6 +10,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include "test_objects.h"
+#include "conf/conf.hpp"
 
 using derecho::ExternalCaller;
 using derecho::Replicated;
@@ -84,12 +85,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     }
 

--- a/derecho/experiments/persistent_latency_test.cpp
+++ b/derecho/experiments/persistent_latency_test.cpp
@@ -13,6 +13,7 @@
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
 #include <persistent/util.hpp>
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -177,12 +178,12 @@ int main(int argc, char *argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/persistent_temporal_query_test.cpp
+++ b/derecho/experiments/persistent_temporal_query_test.cpp
@@ -14,6 +14,7 @@
 #include <mutils-serialization/context_ptr.hpp>
 #include <persistent/Persistent.hpp>
 #include <persistent/util.hpp>
+#include <conf/conf.hpp>
 
 using mutils::context_ptr;
 
@@ -232,12 +233,12 @@ int main(int argc, char *argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/persistent_temporal_stability_test.cpp
+++ b/derecho/experiments/persistent_temporal_stability_test.cpp
@@ -13,6 +13,7 @@
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
 #include <persistent/util.hpp>
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -127,12 +128,12 @@ int main(int argc, char *argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/persistent_typed_subgroup_bw_test.cpp
+++ b/derecho/experiments/persistent_typed_subgroup_bw_test.cpp
@@ -11,6 +11,7 @@
 #include "initialize.h"
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -152,12 +153,12 @@ int main(int argc, char* argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/raw_send_test.cpp
+++ b/derecho/experiments/raw_send_test.cpp
@@ -8,8 +8,9 @@
 #include "block_size.h"
 #include "derecho/derecho.h"
 #include "rdmc/util.h"
+#include "conf/conf.hpp"
 
-static const int GMS_PORT = derecho::derecho_gms_port;
+static const int GMS_PORT = derecho::getConfInt32(CONF_DERECHO_GMS_PORT);
 
 using std::cout;
 using std::endl;

--- a/derecho/experiments/repeated_rpc_test.cpp
+++ b/derecho/experiments/repeated_rpc_test.cpp
@@ -10,6 +10,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include "test_objects.h"
+#include "conf/conf.hpp"
 
 using derecho::ExternalCaller;
 using derecho::Replicated;
@@ -56,12 +57,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory);
     }
 

--- a/derecho/experiments/scaling_subgroup_test.cpp
+++ b/derecho/experiments/scaling_subgroup_test.cpp
@@ -6,6 +6,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include "test_objects.h"
+#include "conf/conf.hpp"
 
 using derecho::ExternalCaller;
 using derecho::Replicated;
@@ -57,12 +58,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo, Bar>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo, Bar>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory);
     }
 

--- a/derecho/experiments/server_client_p2p.cpp
+++ b/derecho/experiments/server_client_p2p.cpp
@@ -3,6 +3,7 @@
 
 #include "derecho/derecho.h"
 #include "initialize.h"
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -72,9 +73,9 @@ int main(int argc, char* argv[]) {
 
     std::unique_ptr<Group<Server>> group;
     if(my_ip == leader_ip) {
-        group = std::make_unique<Group<Server>>(node_id, my_ip, CallbackSet{{}, {}}, subgroup_info, DerechoParams{B + R + 100, (B + R + 100 < 17000 ? B + R + 100 : 0), B + R + 100}, std::vector<view_upcall_t>{announce_groups_provisioned}, derecho_gms_port, server_factory);
+        group = std::make_unique<Group<Server>>(node_id, my_ip, CallbackSet{{}, {}}, subgroup_info, DerechoParams{B + R + 100, (B + R + 100 < 17000 ? B + R + 100 : 0), B + R + 100}, std::vector<view_upcall_t>{announce_groups_provisioned}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT), server_factory);
     } else {
-        group = std::make_unique<Group<Server>>(node_id, my_ip, leader_ip, CallbackSet{{}, {}}, subgroup_info, std::vector<view_upcall_t>{announce_groups_provisioned}, derecho_gms_port, server_factory);
+        group = std::make_unique<Group<Server>>(node_id, my_ip, leader_ip, CallbackSet{{}, {}}, subgroup_info, std::vector<view_upcall_t>{announce_groups_provisioned}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT), server_factory);
     }
 
     cout << "Finished constructing/joining Group" << endl;

--- a/derecho/experiments/shard_iterator_p2p_test.cpp
+++ b/derecho/experiments/shard_iterator_p2p_test.cpp
@@ -1,5 +1,6 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -81,12 +82,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory);
     }
 

--- a/derecho/experiments/smart_membership_function_test.cpp
+++ b/derecho/experiments/smart_membership_function_test.cpp
@@ -16,6 +16,7 @@
 
 #include "derecho/derecho.h"
 #include "initialize.h"
+#include "conf/conf.hpp"
 
 class Cache : public mutils::ByteRepresentable {
     std::map<std::string, std::string> cache_map;
@@ -95,12 +96,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<LoadBalancer, Cache>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 load_balancer_factory, cache_factory);
     } else {
         group = std::make_unique<derecho::Group<LoadBalancer, Cache>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 load_balancer_factory, cache_factory);
     }
     cout << "Finished constructing/joining Group" << endl;

--- a/derecho/experiments/typed_subgroup_bw_test.cpp
+++ b/derecho/experiments/typed_subgroup_bw_test.cpp
@@ -11,6 +11,7 @@
 #include "initialize.h"
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
+#include <conf/conf.hpp>
 
 /**
  * RPC Object with a single function that accepts a string
@@ -77,12 +78,12 @@ int main(int argc, char* argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<TestObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<TestObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/typed_subgroup_test.cpp
+++ b/derecho/experiments/typed_subgroup_test.cpp
@@ -15,6 +15,7 @@
 #include "derecho/derecho.h"
 #include "initialize.h"
 #include "test_objects.h"
+#include "conf/conf.hpp"
 
 using derecho::ExternalCaller;
 using derecho::Replicated;
@@ -87,12 +88,12 @@ int main(int argc, char** argv) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     } else {
         group = std::make_unique<derecho::Group<Foo, Bar, Cache>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 foo_factory, bar_factory, cache_factory);
     }
 

--- a/derecho/experiments/volatile_temporal_query_test.cpp
+++ b/derecho/experiments/volatile_temporal_query_test.cpp
@@ -14,6 +14,7 @@
 #include <mutils-serialization/context_ptr.hpp>
 #include <persistent/Persistent.hpp>
 #include <persistent/util.hpp>
+#include "conf/conf.hpp"
 
 using mutils::context_ptr;
 
@@ -218,12 +219,12 @@ int main(int argc, char *argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/volatile_temporal_stability_test.cpp
+++ b/derecho/experiments/volatile_temporal_stability_test.cpp
@@ -13,6 +13,7 @@
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
 #include <persistent/util.hpp>
+#include "conf/conf.hpp"
 
 using mutils::context_ptr;
 using std::cout;
@@ -135,12 +136,12 @@ int main(int argc, char *argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/experiments/volatile_typed_subgroup_bw_test.cpp
+++ b/derecho/experiments/volatile_typed_subgroup_bw_test.cpp
@@ -11,6 +11,7 @@
 #include "initialize.h"
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <persistent/Persistent.hpp>
+#include "conf/conf.hpp"
 
 using std::cout;
 using std::endl;
@@ -142,12 +143,12 @@ int main(int argc, char* argv[]) {
     if(my_ip == leader_ip) {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, callback_set, subgroup_info, derecho_params,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     } else {
         group = std::make_unique<derecho::Group<ByteArrayObject>>(
                 node_id, my_ip, leader_ip, callback_set, subgroup_info,
-                std::vector<derecho::view_upcall_t>{}, derecho::derecho_gms_port,
+                std::vector<derecho::view_upcall_t>{}, derecho::getConfInt32(CONF_DERECHO_GMS_PORT),
                 ba_factory);
     }
 

--- a/derecho/group.h
+++ b/derecho/group.h
@@ -26,6 +26,7 @@
 #include "subgroup_info.h"
 #include "view_manager.h"
 
+#include "conf/conf.hpp"
 #include "mutils-containers/KindMap.hpp"
 #include "mutils-containers/TypeMap2.hpp"
 #include "spdlog/spdlog.h"
@@ -256,7 +257,7 @@ public:
           const SubgroupInfo& subgroup_info,
           const DerechoParams& derecho_params,
           std::vector<view_upcall_t> _view_upcalls = {},
-          const int gms_port = derecho_gms_port,
+          const int gms_port = getConfInt32(CONF_DERECHO_GMS_PORT),
           Factory<ReplicatedTypes>... factories);
 
     /**
@@ -287,7 +288,7 @@ public:
           const CallbackSet& callbacks,
           const SubgroupInfo& subgroup_info,
           std::vector<view_upcall_t> _view_upcalls = {},
-          const int gms_port = derecho_gms_port,
+          const int gms_port = getConfInt32(CONF_DERECHO_GMS_PORT),
           Factory<ReplicatedTypes>... factories);
 
     ~Group();

--- a/derecho/multicast_group.h
+++ b/derecho/multicast_group.h
@@ -65,7 +65,7 @@ struct DerechoParams : public mutils::ByteRepresentable {
                   unsigned int window_size = 3,
                   unsigned int timeout_ms = 1,
                   rdmc::send_algorithm type = rdmc::BINOMIAL_SEND,
-                  uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT))
+                  uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_RPC_PORT))
             : max_payload_size(max_payload_size),
               sst_max_payload_size(sst_max_payload_size),
               block_size(block_size),
@@ -369,7 +369,7 @@ public:
             uint32_t total_num_subgroups,
             const std::map<subgroup_id_t, SubgroupSettings>& subgroup_settings_by_id,
             const persistence_manager_callbacks_t& _persistence_manager_callbacks,
-            std::vector<char> already_failed = {}, uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT));
+            std::vector<char> already_failed = {}, uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_RPC_PORT));
 
     ~MulticastGroup();
 

--- a/derecho/multicast_group.h
+++ b/derecho/multicast_group.h
@@ -17,7 +17,6 @@
 #include "connection_manager.h"
 #include "derecho_internal.h"
 #include "derecho_modes.h"
-#include "derecho_ports.h"
 #include "derecho_sst.h"
 #include "mutils-serialization/SerializationMacros.hpp"
 #include "mutils-serialization/SerializationSupport.hpp"
@@ -26,6 +25,7 @@
 #include "sst/multicast.h"
 #include "sst/sst.h"
 #include "subgroup_info.h"
+#include "conf/conf.hpp"
 
 namespace derecho {
 
@@ -57,7 +57,7 @@ struct DerechoParams : public mutils::ByteRepresentable {
     unsigned int window_size = 3;
     unsigned int timeout_ms = 1;
     rdmc::send_algorithm type = rdmc::BINOMIAL_SEND;
-    uint32_t rpc_port = derecho_rpc_port;
+    uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_RPC_PORT);
 
     DerechoParams(long long unsigned int max_payload_size,
                   long long unsigned int sst_max_payload_size,
@@ -65,7 +65,7 @@ struct DerechoParams : public mutils::ByteRepresentable {
                   unsigned int window_size = 3,
                   unsigned int timeout_ms = 1,
                   rdmc::send_algorithm type = rdmc::BINOMIAL_SEND,
-                  uint32_t rpc_port = derecho_rpc_port)
+                  uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT))
             : max_payload_size(max_payload_size),
               sst_max_payload_size(sst_max_payload_size),
               block_size(block_size),
@@ -369,7 +369,7 @@ public:
             uint32_t total_num_subgroups,
             const std::map<subgroup_id_t, SubgroupSettings>& subgroup_settings_by_id,
             const persistence_manager_callbacks_t& _persistence_manager_callbacks,
-            std::vector<char> already_failed = {}, uint32_t rpc_port = derecho_rpc_port);
+            std::vector<char> already_failed = {}, uint32_t rpc_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT));
 
     ~MulticastGroup();
 

--- a/derecho/view_manager.h
+++ b/derecho/view_manager.h
@@ -13,12 +13,12 @@
 #include <vector>
 
 #include "derecho_internal.h"
-#include "derecho_ports.h"
 #include "locked_reference.h"
 #include "multicast_group.h"
 #include "subgroup_info.h"
 #include "tcp/tcp.h"
 #include "view.h"
+#include "conf/conf.hpp"
 
 #include <mutils-serialization/SerializationSupport.hpp>
 #include <spdlog/spdlog.h>
@@ -297,7 +297,7 @@ public:
                 const DerechoParams& derecho_params,
                 const persistence_manager_callbacks_t& _persistence_manager_callbacks,
                 std::vector<view_upcall_t> _view_upcalls = {},
-                const int gms_port = derecho_gms_port);
+                const int gms_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT));
 
     /**
      * Constructor for joining an existing group, assuming the caller has already
@@ -322,7 +322,7 @@ public:
                 const SubgroupInfo& subgroup_info,
                 const persistence_manager_callbacks_t& _persistence_manager_callbacks,
                 std::vector<view_upcall_t> _view_upcalls = {},
-                const int gms_port = derecho_gms_port);
+                const int gms_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT));
 
     /**
      * Constructor for recovering a failed node by loading its View from log
@@ -349,7 +349,7 @@ public:
                 const persistence_manager_callbacks_t& _persistence_manager_callbacks,
                 const DerechoParams& derecho_params = DerechoParams(0, 0, 0),
                 std::vector<view_upcall_t> _view_upcalls = {},
-                const int gms_port = derecho_gms_port);
+                const int gms_port = derecho::getConfInt32(CONF_DERECHO_GMS_PORT));
 
     ~ViewManager();
 

--- a/persistent/CMakeLists.txt
+++ b/persistent/CMakeLists.txt
@@ -40,4 +40,4 @@ output_directory(persistent target/usr/local/lib)
 add_dependencies(persistent libfabric_target)
 
 add_executable(ptst test.cpp)
-target_link_libraries(ptst persistent pthread mutils mutils-serialization)
+target_link_libraries(ptst conf persistent pthread mutils mutils-serialization)

--- a/rdmc/CMakeLists.txt
+++ b/rdmc/CMakeLists.txt
@@ -10,13 +10,11 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -std=c++1z -O3 -W
 include_directories(${derecho_SOURCE_DIR})
 include_directories(${derecho_SOURCE_DIR}/third_party/spdlog/include)
 include_directories(${derecho_SOURCE_DIR}/third_party/getpot)
-# include_directories(${derecho_SOURCE_DIR}/third_party/libfabric/build/include)
 include_directories(${derecho_SOURCE_DIR}/third_party/libfabric/include)
-# link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/build/lib)
 link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/src/.libs)
 
 ADD_LIBRARY(rdmc SHARED rdmc.cpp util.cpp group_send.cpp schedule.cpp lf_helper.cpp)
-TARGET_LINK_LIBRARIES(rdmc tcp rdmacm ibverbs rt pthread fabric)
+TARGET_LINK_LIBRARIES(rdmc conf tcp rdmacm ibverbs rt pthread fabric)
 
 find_library(SLURM_FOUND slurm)
 if (SLURM_FOUND)

--- a/sst/CMakeLists.txt
+++ b/sst/CMakeLists.txt
@@ -10,16 +10,14 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -std=c++1z -O3 -W
 include_directories(${derecho_SOURCE_DIR})
 include_directories(${derecho_SOURCE_DIR}/third_party/spdlog/include)
 include_directories(${derecho_SOURCE_DIR}/third_party/getpot)
-# include_directories(${derecho_SOURCE_DIR}/third_party/libfabric/build/include)
 include_directories(${derecho_SOURCE_DIR}/third_party/libfabric/include)
-# link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/build/lib)
 link_directories(${derecho_SOURCE_DIR}/third_party/libfabric/src/.libs)
 
 add_subdirectory(experiments)
 
 # ADD_LIBRARY(sst SHARED verbs.cpp lf.cpp poll_utils.cpp ../derecho/connection_manager.cpp)
 ADD_LIBRARY(sst SHARED lf.cpp poll_utils.cpp ../derecho/connection_manager.cpp)
-TARGET_LINK_LIBRARIES(sst tcp rdmacm fabric ibverbs pthread rt) 
+TARGET_LINK_LIBRARIES(sst conf tcp rdmacm fabric ibverbs pthread rt) 
 add_dependencies(sst libfabric_target)
 
 add_custom_target(format_sst clang-format-3.8 -i *.cpp *.h)

--- a/third_party/getpot/GetPot.cpp
+++ b/third_party/getpot/GetPot.cpp
@@ -2210,7 +2210,7 @@ GetPot::unidentified_nominuses(const STRING_VECTOR& Knowns) const
     return ufos;
 }
 
-bool 
+__GETPOT_INLINE bool 
 GetPot::__constraint_check(const std::string& Value, const char* ConstraintStr, 
                            bool ThrowExceptionF) const
 {
@@ -2249,7 +2249,7 @@ GetPot::__constraint_check(const std::string& Value, const char* ConstraintStr,
  *            'string'
  *            '(' or_expr ')'                             */
 
-bool 
+__GETPOT_INLINE bool 
 GetPot::__constraint_check_OR(const std::string& Value, const char** iterator) const
 {
     bool result = false;
@@ -2264,7 +2264,7 @@ GetPot::__constraint_check_OR(const std::string& Value, const char** iterator) c
     return result;
 }
 
-bool
+__GETPOT_INLINE bool
 GetPot::__constrain_check_EQUAL_STRING(const char* viterator, const char** iterator) const
 {
     ++(*iterator);
@@ -2286,7 +2286,7 @@ GetPot::__constrain_check_EQUAL_STRING(const char* viterator, const char** itera
     return false;
 }
 
-bool 
+__GETPOT_INLINE bool  
 GetPot::__constraint_check_AND(const std::string& Value, const char** iterator) const
 {
     bool result = true;
@@ -2301,7 +2301,7 @@ GetPot::__constraint_check_AND(const std::string& Value, const char** iterator) 
     return result;
 }
 
-bool
+__GETPOT_INLINE bool
 GetPot::__constraint_check_PRIMARY(const std::string& Value, 
                                    const char**       iterator) const
 {


### PR DESCRIPTION
I added a new module 'conf' to manage all configurations like port numbers, RDMA implementation/hardware options, queue pair configurations, etc..

There are many options to specify the configuration file:
1) Call derecho::Conf::initialize() explicitly with the path to the configuration file; or
2) Specify the configuration file with DERECHO_CONF_FILE environment variable; or
3) 'derecho.cfg' in the working directory will be used; or
4) fall back to the default configuration defined in conf/conf.hpp and documented in conf/derecho-default.cfg

Derecho loads configuration in the above order, whichever succeed first.